### PR TITLE
ci: fix workflow files os inputs to use brackets around

### DIFF
--- a/.github/workflows/reusable-basic-test.yml
+++ b/.github/workflows/reusable-basic-test.yml
@@ -7,12 +7,12 @@ on:
         description: "Optional input to set a list of operating systems which the workflow uses. Defaults to ['ubuntu-latest', 'windows-latest', 'macos-latest'] if not set"
         required: false
         type: string
-        default: 'ubuntu-latest'
+        default: '[ubuntu-latest]'
       node-version-file:
         description: "Optional input to set the version of Node.js used to build the project. The input syntax corresponds to the setup-node's format as of v4.2.0"
         required: false
         type: string
-        default: '.nvmrc'
+        default: 'latest'
       node-caching:
         description: "Optional input to set up caching for the setup-node action. The input syntax corresponds to the setup-node's format as of v4.2.0. Set to an empty string if caching isn't needed"
         required: false

--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -7,7 +7,7 @@ on:
         description: "Optional input to set a list of operating systems which the workflow uses. Defaults to 'ubuntu-latest' if not set"
         required: false
         type: string
-        default: 'ubuntu-latest'
+        default: '[ubuntu-latest]'
       node-version-file:
         description: "Optional input to set the version of Node.js used to build the project. The input syntax corresponds to the setup-node's format as of v4.2.0"
         required: false


### PR DESCRIPTION
Fixes workflow files who use an `operating-system` input to put under `strategy > matrix > os` option. Switched the default from being simply `ubuntu-latest` to being `[ubuntu-latest]` to see if that fixes the error.